### PR TITLE
harsh/allow-import-to-complete-if-sui-node-returns-error

### DIFF
--- a/src/wallet_client.ts
+++ b/src/wallet_client.ts
@@ -1,11 +1,7 @@
 import * as bip39 from '@scure/bip39';
 import * as english from '@scure/bip39/wordlists/english';
 import { Ed25519Keypair } from './cryptography/ed25519-keypair';
-import {
-  GetObjectDataResponse,
-  SuiAddress,
-  TransactionEffects,
-} from './types';
+import { GetObjectDataResponse, SuiAddress, TransactionEffects } from './types';
 import { JsonRpcProvider } from './providers/json-rpc-provider';
 import { Coin, SUI_TYPE_ARG } from './types/framework';
 import { RpcTxnDataSerializer } from './signers/txn-data-serializers/rpc-txn-data-serializer';
@@ -117,7 +113,21 @@ export class WalletClient {
         'hex'
       );
       // check if this account exists on Sui or not
-      const response = await this.provider.getObjectsOwnedByAddress(address);
+      // check if this account exists on Sui or not
+      let response: any;
+      try {
+        response = await this.provider.getObjectsOwnedByAddress(address);
+      } catch (err) {
+        response = undefined;
+      }
+      if (!response) {
+        accountMetaData.push({
+          derivationPath,
+          address: address.startsWith('0x') ? address : '0x' + address,
+          publicKey: publicKey.startsWith('0x') ? publicKey : '0x' + publicKey,
+        });
+        break;
+      }
       if (Object.keys(response).length !== 0 || i === 0) {
         accountMetaData.push({
           derivationPath,


### PR DESCRIPTION
This PR fixes the import wallet method of the sdk. Current implementation was such that any error from Sui nodes breaks the import flow and the user is not able to import a new wallet (even on Aptos). Added a try catch block around the sui call to get the account balance so that any errors caught are handled and doesn't break the import flow